### PR TITLE
Begrippenlijst_Common_Ground.md

### DIFF
--- a/Begrippenlijst_Common_Ground.md
+++ b/Begrippenlijst_Common_Ground.md
@@ -1,0 +1,52 @@
+# Begrippenlijst
+Naar aanleiding van een verzoek vanuit de Regiegroep Gegevens- en Berichtenstandaarden is deze begrippenlijst van de meest voorkomende begrippen die in de huidige beweging van ‘Samen organiseren en Common ground actueel zijn opgesteld.
+
+Aan een ieder die hieraan bij kan dragen het verzoek om waar nodig aan te vullen of aan te passen zodat dit overzicht actueel blijft en aansluit bij de behoefte van de doelgroep(en).
+
+## API
+Een application programming interface (API) is een verzameling definities op basis waarvan een computerprogramma kan communiceren met een ander programma of onderdeel (meestal in de vorm van bibliotheken). Vaak vormen API's de scheiding tussen verschillende lagen van abstractie, zodat applicaties op een hoog niveau van abstractie kunnen werken en het minder abstracte werk uitbesteden aan andere programma's. Hierdoor hoeft bijvoorbeeld een tekenprogramma niet te weten hoe het de printer moet aansturen, maar roept het daarvoor een gespecialiseerd stuk software aan in een bibliotheek, via een afdruk-API.
+bron: https://nl.wikipedia.org/wiki/Application_programming_interface 
+
+## Bronsystemen
+Een Bronsysteem is het systeem waaruit een gegeven afkomstig is.
+
+# Berichtstructuurmodel (BSM)
+Een Berichtstructuurmodel (BSM) bevat de berichtstructuren die gebruikt worden in een koppelvlak voor het uitwisselen van gegevens. Een BSM beschrijft de berichtstructuren onafhankelijk van een eventueel te gebruiken formaat. Voorbeelden zijn vraag- en antwoordbericht of een kennisgevingsbericht. Vanuit een BSM kan eenzelfde bericht in verschillende formaten gegenereerd worden.
+
+## Entiteittype
+In een Semantisch Informatiemodel (SIM) worden gegevens en hun relaties beschreven. Deze gegevens worden entiteittypen genoemd omdat het gaat om de structuur en relaties, niet om concrete instances van entiteiten. 
+
+
+## JSON
+JSON of JavaScript Object Notation, is een gestandaardiseerd gegevensformaat. JSON maakt gebruik van voor de mens leesbare tekst in de vorm van data-objecten die bestaan uit een of meer attributen met bijbehorende waarden. Het wordt hoofdzakelijk gebruikt voor uitwisseling van data tussen server en webapplicatie, als een alternatief voor xml.
+
+bron: https://nl.wikipedia.org/wiki/JSON 
+
+## NLX
+NLX is an open source inter-organisational system facilitating federated authentication, secure connecting and protocolling in a large-scale, dynamic API landscape.
+
+bron: https://github.com/VNG-Realisatie/nlx
+
+## Resources
+Onder Resources wordt in deze contect verstaan Web Resources. Een Web Resource wordt gebruikt om te verwijzen naar target van uniform resource identifier (URI). Met een URI wordt een gegeven geidentificeerd wat gebruikt kan worden in bijvoorbeeld gegevensuitwisseling.
+
+bron: https://en.wikipedia.org/wiki/Web_resource
+
+## REST
+Representational state transfer (REST) is een software-architectuur voor gedistribueerde mediasystemen zoals het wereldwijde web.
+
+bron: https://nl.wikipedia.org/wiki/Representational_state_transfer 
+
+## RESTful API
+Een RESTful API is een application program interface (API) die gebruik maakt van de HTTP requests GET, PUT, POST and DELETE om data te verwerken.
+
+bron: http://searchmicroservices.techtarget.com/definition/RESTful-API 
+
+## Semantisch Informatie model (SIM)
+Een Semantisch Informatiemodel (SIM) of conceptueel gegevensmodel definieert welke gegevens in een informatiesysteem vastgelegd kunnen worden, hoe deze gegevens gestructureerd zijn en wat de verbanden zijn tussen die gegevens. Een Semantisch Informatiemodel ligt steeds aan de basis van een in de werkelijkheid gerealiseerde implementatie en is in feite het hoog-niveauontwerp van een (doorgaans relationele) databank. 
+
+bron: https://nl.wikipedia.org/wiki/Conceptueel_datamodel
+
+## Uitwisselingsgegevensmodel (UGM)
+In een Uitwisselingsgegevensmodel (UGM) worden de gegevens en relaties zoals deze in een Semantisch Informatiemodel (SIM) zijn beschreven geoptimaliseerd voor gegevensuitwisseling. Normaliter zal een gegeven in het UGM gelijk zijn aan hetzelfde gegeven in het bijbehorende SIM. Indien noodzakelijk kan een gegeven met relaties geoptimaliseerd worden voor uitwisseling, het zogenaamde "platslaan". De structuren zoals beschreven in het UGM vormen de basis voor de berichten zoals die beschreven staan in het Berichtstructuurmodel (BSM).
+


### PR DESCRIPTION
Uit de vorige Regiegroep is de vraag/actie gekomen een begrippenlijst op te stellen, met in eerste instantie een aantal van de meest voorkomende begrippen in de beweging Common Ground en Samen Organiseren.

Dit is een eerste opzet, commentaar en uitbreidingen zijn van harte welkom!
